### PR TITLE
Initial stab at storing user's public ssh key at launch time

### DIFF
--- a/scripts/ec2/run.coffee
+++ b/scripts/ec2/run.coffee
@@ -8,6 +8,7 @@
 #
 # Commands:
 #   hubot ec2 run - Run an Instance
+#   hubot my key is <public_ssh_key> - Stores the user's public SSH key for use when launching an instance
 #
 # Notes:
 #   --image_id=***      : [optional] The ID of the AMI. If omit it, the ImageId of config is used


### PR DESCRIPTION
1. Adds a new command to store the user's public ssh key
2. Stores that ssh key in `authorized_keys` on launch time. Uses UserData to do so
3. Retains the ability to use a UserData file